### PR TITLE
Fix eventEnd format in UpcomingEventCard

### DIFF
--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/UpcomingEventCardButton.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/UpcomingEventCardButton.swift
@@ -24,7 +24,7 @@ struct UpcomingEventCardButton: View {
                         .font(.system(size: 15))
                         .foregroundColor(.onSurface.opacity(0.7))
                     if let eventDate = event.eventStart.toDate(),
-                       let eventEnd = event.eventEnd.toDate(),
+                       let eventEnd = event.eventEnd.convertToHoursAndMinutes(),
                        let eventStart = event.eventStart.convertToHoursAndMinutes()
                     {
                         Text(String(format: NSLocalizedString("%@, from %@ to %@", comment: ""), eventDate, eventStart, eventEnd))


### PR DESCRIPTION
closes #152 

before
<img width="263" alt="image" src="https://github.com/user-attachments/assets/aeb132ec-61ac-4609-96a2-077bfc5ca83c" />

after
![telegram-cloud-photo-size-2-5260303583264500167-x](https://github.com/user-attachments/assets/36e3a772-766e-4da9-ab18-2773f0896092)
